### PR TITLE
ci(publish.yaml): fix typo on PYPI_TOKEN

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,8 +20,8 @@ jobs:
                 python -m pip install --upgrade pip
                 poetry install
             - name: Deploy to Pypi
-              env: 
-                PYPI_TOKEN: ${{ secrets.PYPY_TOKEN }}
+              env:
+                PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
               run: |
                 poetry config pypi-token.pypi $PYPI_TOKEN
                 poetry run publish --build


### PR DESCRIPTION
it was PYPY_TOKEN. Corrected.